### PR TITLE
fix: message / Matching.ResponseJoinのsendProps内でクラッシュするバグの修正

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -231,7 +231,7 @@ Matching.ResponseJoin = class extends ResponseBase {
     sendProps() {
         const allow = this.isAllow();
         const playerInfos = allow ? this.getPlayerInfos() : [];
-        return super.sendProps({ allow: allow, players: playerInfos().map(info => info.getSendProps()) });
+        return super.sendProps({ allow: allow, players: playerInfos.map(info => info.getSendProps()) });
     }
 
     static checkMessage(message) {


### PR DESCRIPTION
Matching.ResponseJoinのsendProps内でクラッシュするバグを修正します。