### PR TITLE
feat: message / game / 入札レスポンスメッセージのリザルトコード追加

### DIFF
--- a/src/message.js
+++ b/src/message.js
@@ -434,7 +434,9 @@ Game.ResponseBid = class extends ResponseBase {
 
 Game.ResponseBid.ResultCode = {
     success: 0,
-    alreadyBid: -1,
+    invalidTurnNum: -1,
+    invalidBidCard: -2,
+    alreadyBid: -3,
 };
 
 Game.UpdatePlayerBidStatus = class extends Unknown {


### PR DESCRIPTION
入札レスポンスメッセージ(`Game.ResponseBid`)のリザルトコードに「不正なターン番号」と「不正な入札カード」を追加します。